### PR TITLE
fix OS X enum clash

### DIFF
--- a/src/mandelbulber/fractal.cpp
+++ b/src/mandelbulber/fractal.cpp
@@ -33,7 +33,7 @@ int Noise(int seed)
 /**
  * Compute the fractal at the point, in one of the various modes
  *
- * Mode: normal: Returns distance
+ * Mode: normal_mode: Returns distance
  *		 fake_ao: Returns minimum radius
  *		 colouring: Returns colour index
  *		 delta_DE1, delta_DE2: Returns radius
@@ -1150,7 +1150,7 @@ double Compute(CVector3 z, const sFractal &par, int *iter_count)
 		}
 		else
 		{
-			if (Mode == normal) //condition for all other trigonometric and hypercomplex fractals
+			if (Mode == normal_mode) //condition for all other trigonometric and hypercomplex fractals
 			{
 				if (r > 1e2)
 				{
@@ -1206,7 +1206,7 @@ double Compute(CVector3 z, const sFractal &par, int *iter_count)
 	if (iter_count != NULL)
 		*iter_count = L;
 
-	if (Mode == normal)
+	if (Mode == normal_mode)
 	{
 		if (L == N)
 			distance = 0;

--- a/src/mandelbulber/fractal.h
+++ b/src/mandelbulber/fractal.h
@@ -68,7 +68,7 @@ enum enumFractalFormula
 
 enum enumCalculationMode
 {
-	normal = 0, colouring = 1, fake_AO = 2, deltaDE1 = 3, deltaDE2 = 4, orbitTrap = 5
+	normal_mode = 0, colouring = 1, fake_AO = 2, deltaDE1 = 3, deltaDE2 = 4, orbitTrap = 5
 };
 
 enum enumGeneralizedFoldBoxType

--- a/src/mapgen_math.cpp
+++ b/src/mapgen_math.cpp
@@ -278,9 +278,9 @@ MapgenMath::MapgenMath(int mapgenid, MapgenParams *params_, EmergeManager *emerg
 	//par.IFS.foldingCount = params.get("IFS.foldingCount", 1).asInt();
 
 	if (params["mode"].asString() == "")
-		mg_params->mode = normal;
+		mg_params->mode = normal_mode;
 	if (params["mode"].asString() == "normal")
-		mg_params->mode = normal;
+		mg_params->mode = normal_mode;
 	if (params["mode"].asString() == "colouring")
 		mg_params->mode = colouring;
 	if (params["mode"].asString() == "fake_AO")


### PR DESCRIPTION
Fix for https://github.com/freeminer/freeminer/issues/99: rename Freeminer enum to remove clash with OS X system enum.
