### PR TITLE
Tweak some default settings for enhanced gameplay

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -258,14 +258,22 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("farmesh_wanted", "500");
 	
 	// Liquid
+#if defined(_WIN32)
 	settings->setDefault("liquid_real", "false");
+#else
+	settings->setDefault("liquid_real", "true");
+#endif
 	settings->setDefault("liquid_update", "0.1");
 	settings->setDefault("liquid_send", "1.0");
 	settings->setDefault("liquid_relax", "2");
 	settings->setDefault("liquid_fast_flood", "1");
 	
 	// Weather
+#if defined(_WIN32)
 	settings->setDefault("weather", "false");
+#else
+	settings->setDefault("weather", "true");
+#endif
 	settings->setDefault("weather_heat_season", "30");
 	settings->setDefault("weather_heat_daily", "8");
 	settings->setDefault("weather_heat_width", "3000");


### PR DESCRIPTION
This PR tweaks a few of the default settings.
- You can now walk, run and crouch slightly faster.
- Weather and real liquids are disabled by default so the game runs **much more smoothly**. If you want to use weather/real liquids you can just enable them in the settings menu instead.
