### PR TITLE
Fix hotbar background

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 hud.cpp
 Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 Copyright (C) 2010-2013 blue42u, Jonathon Anderson <anderjon@umail.iu.edu>
@@ -170,14 +170,6 @@ void Hud::drawItems(v2s32 upperleftpos, s32 itemcount, s32 offset,
 		g_touchscreengui->resetHud();
 #endif
 
-	s32 height  = m_hotbar_imagesize + m_padding * 2;
-	s32 width   = (itemcount - offset) * (m_hotbar_imagesize + m_padding * 2);
-
-	if (direction == HUD_DIR_TOP_BOTTOM || direction == HUD_DIR_BOTTOM_TOP) {
-		width  = m_hotbar_imagesize + m_padding * 2;
-		height = (itemcount - offset) * (m_hotbar_imagesize + m_padding * 2);
-	}
-
 	// Position of upper left corner of bar
 	v2s32 pos = upperleftpos;
 
@@ -199,14 +191,20 @@ void Hud::drawItems(v2s32 upperleftpos, s32 itemcount, s32 offset,
 
 	/* draw customized item background */
 	if (use_hotbar_image) {
-		core::rect<s32> imgrect2(-m_padding/2, -m_padding/2,
-				width+m_padding/2, height+m_padding/2);
-		core::rect<s32> rect2 = imgrect2 + pos;
 		video::ITexture *texture = tsrc->getTexture(hotbar_image);
 		core::dimension2di imgsize(texture->getOriginalSize());
-		driver->draw2DImage(texture, rect2,
-			core::rect<s32>(core::position2d<s32>(0,0), imgsize),
-			NULL, hbar_colors, true);
+		core::rect<s32> rect(-m_padding, -m_padding,
+			m_hotbar_imagesize + m_padding, m_hotbar_imagesize + m_padding);
+		rect += pos;
+		core::position2d<s32> step(0, 0);
+		(direction == HUD_DIR_TOP_BOTTOM || direction == HUD_DIR_BOTTOM_TOP ?
+			step.Y : step.X) = m_hotbar_imagesize + m_padding * 2;
+		for (int i = 0; i < itemcount - offset; i++) {
+			driver->draw2DImage(texture, rect,
+				core::rect<s32>(core::position2d<s32>(0, 0), imgsize),
+				NULL, hbar_colors, true);
+			rect += step;
+		}
 	}
 
 	for (s32 i = offset; i < itemcount && (size_t)i < mainlist->getSize(); i++)
@@ -214,7 +212,8 @@ void Hud::drawItems(v2s32 upperleftpos, s32 itemcount, s32 offset,
 		v2s32 steppos;
 		s32 fullimglen = m_hotbar_imagesize + m_padding * 2;
 
-		core::rect<s32> imgrect(0, 0, m_hotbar_imagesize, m_hotbar_imagesize);
+		core::rect<s32> imgrect(-m_padding, -m_padding,
+			m_hotbar_imagesize - m_padding, m_hotbar_imagesize - m_padding);
 
 		switch (direction) {
 			case HUD_DIR_RIGHT_LEFT:
@@ -425,7 +424,7 @@ void Hud::drawHotbar(u16 playeritem) {
 		pos.X += width/4;
 
 		v2s32 secondpos = pos;
-		pos = pos - v2s32(0, m_hotbar_imagesize + m_padding);
+		pos = pos - v2s32(0, m_hotbar_imagesize + m_padding * 2);
 
 		if (player->hud_flags & HUD_FLAG_HOTBAR_VISIBLE) {
 			drawItems(pos, hotbar_itemcount/2, 0, mainlist, playeritem + 1, 0);

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -91,7 +91,7 @@ u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
 	return MYMAX(f.light_source, light);
 }
 
-u8 MapNode::getLightNoChecks(enum LightBank bank, const ContentFeatures *f)
+u8 MapNode::getLightNoChecks(enum LightBank bank, const ContentFeatures *f) const
 {
 	return MYMAX(f->light_source,
 	             bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f);

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -213,7 +213,7 @@ struct MapNode
 	 * @pre f != NULL
 	 * @pre f->param_type == CPT_LIGHT
 	 */
-	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f);
+	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f) const;
 
 	bool getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const;
 	
@@ -265,7 +265,7 @@ struct MapNode
 	u8 addLevel(INodeDefManager *nodemgr, s8 add = 1, bool compress = 0);
 	int freeze_melt(INodeDefManager *nodemgr, int direction = 0);
 
-	operator bool() const { return param0; };
+	operator bool() const { return param0; }
 
 	/*
 		Serialization functions


### PR DESCRIPTION
https://github.com/freeminer/freeminer/issues/178

You should replace games/default/mods/default/textures/gui_hotbar.png with 
![gui_hotbar](https://cloud.githubusercontent.com/assets/1615889/5556349/53b7eaba-8cfa-11e4-8980-a8c8b73c5999.png).

Some screens:
![2014 12 26_12 43 32 550410562](https://cloud.githubusercontent.com/assets/1615889/5556412/61e277c0-8cfc-11e4-9208-74c171a997da.png)
![2014 12 26_12 43 44 504426659](https://cloud.githubusercontent.com/assets/1615889/5556413/6535d926-8cfc-11e4-82a5-d98da8ee40a7.png)
