### PR TITLE
Code cleanup - sign compare compiler warning for the following:

### DIFF
--- a/src/cguittfont/CGUITTFont.cpp
+++ b/src/cguittfont/CGUITTFont.cpp
@@ -87,10 +87,10 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 			const u32 image_pitch = image->getPitch() / sizeof(u16);
 			u16* image_data = (u16*)image->lock();
 			u8* glyph_data = bits.buffer;
-			for (int y = 0; y < bits.rows; ++y)
+			for (unsigned int y = 0; y < bits.rows; ++y)
 			{
 				u16* row = image_data;
-				for (int x = 0; x < bits.width; ++x)
+				for (unsigned int x = 0; x < bits.width; ++x)
 				{
 					// Monochrome bitmaps store 8 pixels per byte.  The left-most pixel is the bit 0x80.
 					// So, we go through the data each bit at a time.
@@ -116,10 +116,10 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 			const u32 image_pitch = image->getPitch() / sizeof(u32);
 			u32* image_data = (u32*)image->lock();
 			u8* glyph_data = bits.buffer;
-			for (int y = 0; y < bits.rows; ++y)
+			for (unsigned int y = 0; y < bits.rows; ++y)
 			{
 				u8* row = glyph_data;
-				for (int x = 0; x < bits.width; ++x)
+				for (unsigned int x = 0; x < bits.width; ++x)
 				{
 					image_data[y * image_pitch + x] |= static_cast<u32>(255.0f * (static_cast<float>(*row++) / gray_count)) << 24;
 					//data[y * image_pitch + x] |= ((u32)(*bitsdata++) << 24);
@@ -462,7 +462,7 @@ CGUITTGlyphPage* CGUITTFont::getLastGlyphPage() const
 CGUITTGlyphPage* CGUITTFont::createGlyphPage(const u8& pixel_mode)
 {
 	CGUITTGlyphPage* page = 0;
-	
+
 	// Name of our page.
 	io::path name("TTFontGlyphPage_");
 	name += tt_face->family_name;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1010,7 +1010,7 @@ void CNodeDefManager::msgpack_unpack(msgpack::object o)
 
 	for (std::map<int, ContentFeatures>::iterator it = unpacked_features.begin();
 			it != unpacked_features.end(); ++it) {
-		int i = it->first;
+		unsigned int i = it->first;
 		ContentFeatures f = it->second;
 
 		if(i == CONTENT_IGNORE || i == CONTENT_AIR


### PR DESCRIPTION
Code cleanup - sign compare compiler warning for the following:

- changed "int i = it->first" to "unsigned int i = it->first" on line 1013 of /src/nodedef.cpp
- changed "int y" in for statements on lines 90,93,119,122 in /src/cguittfont/CGUITTFont.cpp to "unsigned int y"

Compiled on Arch Linux with g++ 4.9.2