### PR TITLE
Fix build instructions for Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pacaur -Sa msgpack-c-0.5
 ___
 Gentoo/Funtoo:
 ```bash
-emerge -av media-libs/libvorbis media-libs/openal dev-games/irrlicht dev-libs/msgpack dev-libs/leveldb
+emerge -av media-libs/libvorbis media-libs/openal dev-games/irrlicht '<dev-libs/msgpack-1.0.0' dev-libs/leveldb
 ```
 ___
 Osx:


### PR DESCRIPTION
Once msgpack fixes their problem (presuming it really is their problem),
this fix should be changed to mask the range of bad versions in
package.mask.