### PR TITLE
Add drop shortcuts

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1576,6 +1576,7 @@ protected:
 	void processItemSelection(u16 *new_playeritem);
 
 	void dropSelectedItem();
+	void dropSelectedStack();
 	void openInventory();
 	void openConsole(float height = 0.6, bool close_on_return = false, const std::wstring& input = L"");
 	void toggleFreeMove(float *statustext_time);
@@ -2802,7 +2803,15 @@ void Game::processKeyboardInput(VolatileRunFlags *flags,
 	//TimeTaker tt("process kybd input", NULL, PRECISION_NANO);
 
 	if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_DROP])) {
-		dropSelectedItem();
+#ifdef __ANDROID__
+		dropSelectedStack();
+#else
+		if (input->isKeyDown(LControlKey) || input->isKeyDown(RControlKey)) {
+			dropSelectedStack();
+		} else {
+			dropSelectedItem();
+		}
+#endif
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_INVENTORY])) {
 		openInventory();
 	} else if (input->wasKeyDown(EscapeKey) || input->wasKeyDown(CancelKey)) {
@@ -2994,13 +3003,22 @@ void Game::processItemSelection(u16 *new_playeritem)
 void Game::dropSelectedItem()
 {
 	IDropAction *a = new IDropAction();
-	a->count = 0;
+	a->count = 1;
 	a->from_inv.setCurrentPlayer();
 	a->from_list = "main";
 	a->from_i = client->getPlayerItem();
 	client->inventoryAction(a);
 }
 
+void Game::dropSelectedStack()
+{
+	IDropAction *a = new IDropAction();
+	a->count = 0;
+	a->from_inv.setCurrentPlayer();
+	a->from_list = "main";
+	a->from_i = client->getPlayerItem();
+	client->inventoryAction(a);
+}
 
 void Game::openInventory()
 {

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -3056,6 +3056,74 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			return true;
 		}
 
+		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_drop")) {
+
+			// get item
+			ItemSpec s = getItemAtPos(m_pointer);
+			Inventory *inv_s = NULL;
+
+			if(s.isValid())
+			do { // breakable
+				inv_s = m_invmgr->getInventory(s.inventoryloc);
+
+				if(!inv_s) {
+					errorstream << "InventoryMenu: The selected inventory location "
+							<< "\"" << s.inventoryloc.dump() << "\" doesn't exist"
+							<< std::endl;
+					s.i = -1;  // make it invalid again
+					break;
+				}
+
+				InventoryList *list_from = inv_s->getList(s.listname);
+				if(list_from == NULL) {
+					verbosestream << "InventoryMenu: The selected inventory list \""
+							<< s.listname << "\" does not exist" << std::endl;
+					s.i = -1;  // make it invalid again
+					break;
+				}
+
+				if((u32)s.i >= list_from->getSize()) {
+					infostream << "InventoryMenu: The selected inventory list \""
+							<< s.listname<<"\" is too small (i=" << s.i << ", size="
+							<< list_from->getSize() << ")" << std::endl;
+					s.i = -1;  // make it invalid again
+					break;
+				}
+
+				ItemStack stack_from = list_from->getItem(s.i);
+				if(stack_from.count<=0)
+					break;
+
+				u32 drop_amount = 0;
+
+				if (event.KeyInput.Control) {
+					// if drop key + ctrl = drop full stack
+					drop_amount = stack_from.count;
+				} else {
+					// if drop key without ctrl = drop one item
+					drop_amount = 1;
+				}
+
+				// Send IACTION_DROP
+
+				// Check how many items can be dropped
+				drop_amount = stack_from.count = MYMIN(drop_amount, stack_from.count);
+				if(drop_amount == 0 || drop_amount > stack_from.count)
+					break;
+
+				infostream << "Handing IACTION_DROP to manager" << std::endl;
+
+				IDropAction *a = new IDropAction();
+				a->count = drop_amount;
+				a->from_inv = s.inventoryloc;
+				a->from_list = s.listname;
+				a->from_i = s.i;
+				m_invmgr->inventoryAction(a);
+
+			} while(0);
+		}
+
+
 	}
 
 	/* Mouse event other than movement, or crossing the border of inventory

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -341,6 +341,11 @@ const char *KeyPress::name() const
 	}
 }
 
+const KeyPress LControlKey("KEY_LCONTROL");
+const KeyPress RControlKey("KEY_RCONTROL");
+const KeyPress LShiftKey("KEY_LSHIFT");
+const KeyPress RShiftKey("KEY_RSHIFT");
+
 const KeyPress EscapeKey("KEY_ESCAPE");
 const KeyPress CancelKey("KEY_CANCEL");
 const KeyPress NumberKey[] = {

--- a/src/keycode.h
+++ b/src/keycode.h
@@ -60,6 +60,11 @@ protected:
 	std::string m_name;
 };
 
+extern const KeyPress LControlKey;
+extern const KeyPress RControlKey;
+extern const KeyPress LShiftKey;
+extern const KeyPress RShiftKey;
+
 extern const KeyPress EscapeKey;
 extern const KeyPress CancelKey;
 extern const KeyPress NumberKey[10];


### PR DESCRIPTION
Add drop key combinations.
In the game: `drop key` drop one item; `drop key` + `ctrl` drop full stack.
In inventory: `drop key` drop one item from slot under the mouse; `drop key` + `ctrl` drop full stack under the mouse