### PR TITLE
Fixed the world format description

### DIFF
--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -316,7 +316,7 @@ if map format version >= 23:
       u8[key_len] key
       u32 val_len
       u8[val_len] value
-      serialized inventory
+    serialized inventory
 
 - Node timers
 if map format version == 23:


### PR DESCRIPTION
Fixed a minor mistake that made it appear as if inventory is serialized multiple times - one per each variable. In fact it is serialized once per each node.