### PR TITLE
Make ItemStack with different metadata not stackable

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -338,8 +338,9 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 		*this = newitem;
 		newitem.clear();
 	}
-	// If item name differs, bail out
-	else if(name != newitem.name)
+	// If item name or metadata differs, bail out
+	else if(name != newitem.name or
+            metadata != newitem.metadata)
 	{
 		// cannot be added
 	}
@@ -378,8 +379,9 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 		newitem.clear();
 	}
 	// If item name differs, bail out
-	else if(name != newitem.name)
-	{
+	else if(name != newitem.name or
+            metadata != newitem.metadata)
+    {
 		// cannot be added
 	}
 	// If the item fits fully, delete it


### PR DESCRIPTION
When you are trying to stack items with different meta they stack and added item lose its meta. 

This pull request forbids stacking such items.